### PR TITLE
Add trang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,30 @@ ENV TERM xterm
 RUN echo "Installing apt-get packages" && \
 
     # Pull package lists and upgrade existing packages.
+    apt-get clean && \
     apt-get update && \
     apt-get dist-upgrade -y && \
 
     # Install all the required dependencies
-    apt-get install -y wget perl python3 python3-dev python3-pip git tar fontconfig cpanminus libxml2-dev libxslt-dev libssl-dev libgdbm-dev liblwp-protocol-https-perl perlmagick openjdk-7-jre-headless bindfs && \
+    apt-get install -y \
+    bindfs \
+    cpanminus \
+    fontconfig \
+    git \
+    libgdbm-dev \
+    liblwp-protocol-https-perl \
+    libssl-dev \
+    libxml2-dev \
+    libxslt-dev \
+    openjdk-7-jre-headless \
+    perl \
+    perlmagick \
+    python3 \
+    python3-dev \
+    python3-pip \
+    tar \
+    trang \
+    wget && \
 
     # Clear apt-get caches to save space
     apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Follow up from https://github.com/KWARC/localmh_docker/pull/30:

I ran into `error reading from server` during the build process, so I had to add `apt-get clean` before `apt-get update` as suggested in http://serverfault.com/questions/690639/api-get-error-reading-from-server-under-docker:

I built the image using:

```
docker build -no-cache -t test .
```

and was able to get trang installed successfully 

``` shell
dyn1222-18:localmh_docker Hang$ docker run -t -i test /bin/bash
root@4149e0799b69:/# trang
fatal: at least two arguments are required
Trang version 20131210
usage: java com.thaiopensource.relaxng.translate.Driver [-C catalogFileOrUri] [-I rng|rnc|dtd|xml] [-O rng|rnc|dtd|xsd] [-i input-param] [-o output-param] inputFileOrUri ... outputFile
```

I also refactored the package list a bit following Docker' recommendation, multiline alphabetic ordering.
